### PR TITLE
adjusting egrep to get the kernel version without .img

### DIFF
--- a/centos7-ami-builder.sh
+++ b/centos7-ami-builder.sh
@@ -338,7 +338,7 @@ setup_network() {
 install_grub() {
 	
 	AMI_BOOT_PATH=$AMI_MNT/boot
-	AMI_KERNEL_VER=$(ls $AMI_BOOT_PATH | egrep -o '3\..*' | head -1)
+	AMI_KERNEL_VER=$(ls $AMI_BOOT_PATH | egrep -o '4\..*' | head -1)
 
 	# Install our grub.conf for only the PV machine, as it is needed by PV-GRUB
 	if [[ $AMI_TYPE == "pv" ]]; then


### PR DESCRIPTION
removing .img off the kernel version for pv-grub and grub install
