### PR TITLE
Match on 3 (legacy) or 4 (elrepo)

### DIFF
--- a/centos7-ami-builder.sh
+++ b/centos7-ami-builder.sh
@@ -339,7 +339,7 @@ setup_network() {
 install_grub() {
 	
 	AMI_BOOT_PATH=$AMI_MNT/boot
-	AMI_KERNEL_VER=$(ls $AMI_BOOT_PATH | egrep -o '4\..*' | head -1)
+	AMI_KERNEL_VER=$(ls $AMI_BOOT_PATH | egrep -o '(3|4)\..*' | head -1)
 
 	# Install our grub.conf for only the PV machine, as it is needed by PV-GRUB
 	if [[ $AMI_TYPE == "pv" ]]; then


### PR DESCRIPTION
In our appliance builder we don't use epel of elrepo when creating our base yum.conf, so this way it will match on either the legacy centos7 kernel (version 3.x) or a newer kernel (version 4.x). 
